### PR TITLE
Export network-wide tokenomics metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ Dimensions:
  - `state` one of `active`, `inactive`, `liquidated`
  - `operators` comma separated list of cluster operators integer identifiers in SSV system
 
+----------
+
+`ssv_network_fee` -- current SSV network fee as described in [https://docs.ssv.network/learn/protocol-overview/tokenomics/fees#k4tw9to38r3v](SSV tokenomics docs)
+
+Dimensions:
+ - `network` one of `mainnet`, `holesky`
+
+----------
+
+`ssv_minimum_liquidation_collateral` -- current SSV minimum liquidation collateral as described in [https://docs.ssv.network/learn/protocol-overview/tokenomics/liquidations#minimum-liquidation-collateral](SSV tokenomics docs)
+
+Dimensions:
+ - `network` one of `mainnet`, `holesky`
+
+
+----------
+
+`ssv_liquidation_threshold_period` -- current SSV liquidation threshold period as described in [https://docs.ssv.network/learn/protocol-overview/tokenomics/liquidations#liquidation-threshold-period](SSV tokenomics docs)
+
+Dimensions:
+ - `network` one of `mainnet`, `holesky`
+
 
 
 Installation

--- a/tests.py
+++ b/tests.py
@@ -77,8 +77,19 @@ async def test_metrics(metrics_server: str) -> None:
                 sample.labels["owner"] == "0xD4BB555d3B0D7fF17c606161B44E372689C14F4B"
             )
             matched_metrics.add(metric.name)
+        elif metric.name in (
+            "ssv_network_fee",
+            "ssv_minimum_liquidation_collateral",
+            "ssv_liquidation_threshold_period",
+        ):
+            sample = metric.samples[0]
+            assert sample.labels["network"] == "holesky"
+            matched_metrics.add(metric.name)
     assert matched_metrics == {
         "ssv_cluster_validators_count",
         "ssv_cluster_balance",
         "ssv_cluster_burn_rate",
+        "ssv_network_fee",
+        "ssv_minimum_liquidation_collateral",
+        "ssv_liquidation_threshold_period",
     }


### PR DESCRIPTION
After update in https://github.com/ChorusOne/ssv-cluster-exporter/pull/3 the cluster specific metrics are now matching reality. But, to calculate exact amount of days left for the cluster, need to have network wide metrics like minimum liquidation collateral and liquidation threshold period.